### PR TITLE
Add customization option for `pop-to-buffer`

### DIFF
--- a/gumshoe.el
+++ b/gumshoe.el
@@ -56,6 +56,12 @@
   "Gumshoe automatically logs your position if you’ve been idle at POINT for this amount of time."
   :type 'integer)
 
+(defcustom gumshoe-display-buffer-action nil
+  "Which `display-buffer' ACTION argument to use when switching to another buffer.
+
+See `display-buffer' for more information"
+  :type 'list)
+
 (defclass gumshoe--backlog ()
   ((log :initform (make-ring gumshoe-log-len)
         :documentation "Ring-buffer to remember the previous editing position.")
@@ -128,7 +134,7 @@
   "Move to MARKER point and associated buffer."
   (let ((buf  (marker-buffer marker)))
     (when buf
-      (pop-to-buffer buf)
+      (pop-to-buffer buf gumshoe-display-buffer-action)
       (goto-char marker))))
 
 (cl-defmethod backtrack-back ((self gumshoe--backlog))


### PR DESCRIPTION
First of I would like to say thanks for an awesome package. I have
been thinking of creating something similar for ages as I have not
been the biggest fan of evil's jumplist and I think this is
great. Can't wait for this to be on melpa as I am not a straight user.

The default `display-buffer` action for `pop-to-buffer` with my usage
of this great package makes my skin crawl. Probably due to being an
old vim user. Personally I prefer the ACTION
`display-buffer-same-window` but obviously that is not the case for
everyone. So I thought it would be nice if the behavior could be
customized. As

```
(setq gumshoe-display-buffer-action '(display-buffer-same-window))
```

And maybe it helps someone else if the custom takes specifies the
ACTION argument to align this great package with someone else's
workflow.