### PR TITLE
gumshoe-core: Add option to prefer same window

### DIFF
--- a/gumshoe-core.el
+++ b/gumshoe-core.el
@@ -67,6 +67,10 @@
   "Entry slot order for perusing the backlog."
   :type 'list)
 
+(defcustom gumshoe-prefer-same-window nil
+  "Prefer jumping using the window where point currently is."
+  :type 'boolean)
+
 (defface gumshoe--peruse-separator-face
   '((t
      :inherit diary))
@@ -114,7 +118,9 @@ See `display-buffer' for more information"
 (cl-defmethod gumshoe--jump ((self gumshoe--entry))
   "Jump Point to buffer and position in SELF."
   (with-slots (buffer position) self
-    (pop-to-buffer buffer)
+    (if gumshoe-prefer-same-window
+        (pop-to-buffer-same-window buffer)
+      (pop-to-buffer buffer))
     (goto-char position)))
 
 ;;; filter predicates


### PR DESCRIPTION
When t, this flag uses `pop-to-buffer-same-window` instead of `pop-to-buffer` for
jumping, making it so that jumps occur in the current window when possible
(e.g. non-dedicated / non-minibuffer locations) rather than popping up a different window.

I believe this fixes https://github.com/Overdr0ne/gumshoe/issues/9